### PR TITLE
Finding historical neighbors for newly seen links

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -169,8 +169,14 @@ class NeighborSampler:
         # extracts all neighbors ids, edge ids and interaction times of nodes in node_ids, which happened before the corresponding time in node_interact_times
         for idx, (node_id, node_interact_time) in enumerate(zip(node_ids, node_interact_times)):
             # find neighbors that interacted with node_id before time node_interact_time
-            node_neighbor_ids, node_edge_ids, node_neighbor_times, node_neighbor_sampled_probabilities = \
-                self.find_neighbors_before(node_id=node_id, interact_time=node_interact_time, return_sampled_probabilities=self.sample_neighbor_strategy == 'time_interval_aware')
+            if node_id >= len(self.nodes_neighbor_ids):
+                node_neighbor_ids = np.empty(0)
+                node_edge_ids = np.empty_like(node_neighbor_ids)
+                node_neighbor_times = np.empty_like(node_neighbor_ids)
+                node_neighbor_sampled_probabilities = np.empty_like(node_neighbor_ids)
+            else:
+                node_neighbor_ids, node_edge_ids, node_neighbor_times, node_neighbor_sampled_probabilities = \
+                    self.find_neighbors_before(node_id=node_id, interact_time=node_interact_time, return_sampled_probabilities=self.sample_neighbor_strategy == 'time_interval_aware')
 
             if len(node_neighbor_ids) > 0:
                 if self.sample_neighbor_strategy in ['uniform', 'time_interval_aware']:


### PR DESCRIPTION
Hello, First thanks for the great contribution of your work! This pull request addresses the cases where there’s no historical data for a link (such as forwarding unseen negative links to the TGAT model), which currently an exception is raised due to missing neighbors for the relevant nodes. This code update handles this by adding an if-else statement to skip the `find_neighbors_before` function when no neighbors has been recorded for the nodes involved.